### PR TITLE
Break up section split with icon

### DIFF
--- a/website/src/styles/index.css
+++ b/website/src/styles/index.css
@@ -123,6 +123,27 @@ section:nth-of-type(even) {
 	color: #0065bf;
 }
 
+
+section::after {
+	content: "⎈";
+	position: relative;
+	display: block;
+	bottom: -45px;
+	margin: 0 auto;
+	width: 60px;
+	height: 60px;
+	background: #fff;
+	color: #0065bf;
+	font-size: 3em;
+	text-align: center;
+	z-index: 9;
+	border-radius: 30px;
+}
+
+section:last-of-type::after {
+	display: none;
+}
+
 .fig-holder a {
 	display: inline-block;
 	border: none;


### PR DESCRIPTION
Break up the harsh solid lines between sections with the same icon used for header and footer separator.

![CleanShot 2022-07-23 at 12 22 01](https://user-images.githubusercontent.com/3384072/180602958-c77c29d6-bbde-4aca-84d6-88c3c98102d0.png)
