### PR TITLE
UI fixes

### DIFF
--- a/website/2023/toronto/src/components/Footer/Footer.astro
+++ b/website/2023/toronto/src/components/Footer/Footer.astro
@@ -5,7 +5,7 @@ const { path } = Astro.props;
 <footer class="footer">
   <div>
     <nav>
-      <a href="/code-of-conduct"><h4>Code of Conduct</h4></a>
+      <a href="/2023/toronto/code-of-conduct"><h4>Code of Conduct</h4></a>
       <h4>Contact</h4>
       <div class="links">
         <a href="https://rawkode.chat/">Join our Discord community</a>

--- a/website/2023/toronto/src/pages/code-of-conduct.astro
+++ b/website/2023/toronto/src/pages/code-of-conduct.astro
@@ -186,35 +186,36 @@ const content = {
           >https://www.contributor-covenant.org/translations</a
         >.
       </p>
+
+      <section class="formats">
+        <dl class="formats">
+          <dt>Other formats:</dt>
+
+          <dd>
+            <a
+              class="icon icon-text/markdown"
+              href="https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md"
+              ><abbr title="markdown">text/markdown</abbr>
+            </a>
+          </dd>
+
+          <dd>
+            <a
+              class="icon icon-text/plain"
+              href="https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.txt"
+              ><abbr title="plaintext">text/plain</abbr>
+            </a>
+          </dd>
+
+          <dd>
+            <a
+              class="icon icon-text/asciidoc"
+              href="https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.adoc"
+              ><abbr title="asciidoc">text/asciidoc</abbr>
+            </a>
+          </dd>
+        </dl>
+      </section>
     </div>
-    <section class="formats">
-      <dl class="formats">
-        <dt>Other formats:</dt>
-
-        <dd>
-          <a
-            class="icon icon-text/markdown"
-            href="https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md"
-            ><abbr title="markdown">text/markdown</abbr>
-          </a>
-        </dd>
-
-        <dd>
-          <a
-            class="icon icon-text/plain"
-            href="https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.txt"
-            ><abbr title="plaintext">text/plain</abbr>
-          </a>
-        </dd>
-
-        <dd>
-          <a
-            class="icon icon-text/asciidoc"
-            href="https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.adoc"
-            ><abbr title="asciidoc">text/asciidoc</abbr>
-          </a>
-        </dd>
-      </dl>
-    </section>
   </section>
 </MainLayout>

--- a/website/2023/toronto/src/pages/index.astro
+++ b/website/2023/toronto/src/pages/index.astro
@@ -373,7 +373,7 @@ const content = {
 
       <p>
         If you’d like to support this conference, you can find details on our <a
-          href="/sponsorship">sponsorship opportunities page</a
+          href="/2023/toronto/sponsorship">sponsorship opportunities page</a
         >.
       </p>
 

--- a/website/2023/toronto/src/pages/index.astro
+++ b/website/2023/toronto/src/pages/index.astro
@@ -352,14 +352,15 @@ const content = {
         schedule to be announced when speakers are finalized
       </p> -->
 
-      <div class="fig-holder center">
+      <div class="center">
         <a
           class="big-button"
           href="https://sessionize.com/kubehuddle-Toronto-2023/"
-          >Call for Speakers</a
-        >
+          >Call for Speakers</a>
         <p class="keynote">Keynote Speakers</p>
-        {data.map((speakers) => <Speaker {speakers} />)}
+        <div class="fig-holder">
+          {data.map((speakers) => <Speaker {speakers} />)}
+        </div>
       </div>
     </div>
     <div class="blue-leaf-container3">

--- a/website/2023/toronto/src/styles/index.css
+++ b/website/2023/toronto/src/styles/index.css
@@ -229,7 +229,7 @@ section:last-of-type::after {
 }
 
 .blueleaf_img {
-	width: 3%;
+	width: 60px;
 	position: absolute;
 	top: 90%;
 	z-index: 10;
@@ -363,7 +363,7 @@ section:last-of-type::after {
 		display: flex;
 		justify-content: end;
 		line-height: 1;
-	
+
 	}
 	.ticket_size{
 		font-size: 13px;


### PR DESCRIPTION
* Fix leak logo on ultra-wide monitors
![Screenshot 2023-02-13 at 9 43 55 am](https://user-images.githubusercontent.com/3384072/218424100-01e24a9a-8fe6-4149-81e7-2fa99d46d70c.png)
* Ensure sponsorship and Code of Conduct links point to correct pages
* Fix the alignment of the other formats on the CoC page
![Screenshot 2023-02-13 at 9 44 54 am](https://user-images.githubusercontent.com/3384072/218424336-61a3ae54-a808-4627-8777-6cfc58e8dd04.png)
* Fix the speak figure layout (to hide the erroneous close buttons)
![Screenshot 2023-02-13 at 9 45 09 am](https://user-images.githubusercontent.com/3384072/218424382-1b12f324-b88f-4ed4-b357-eca575fad66a.png)
