### PR TITLE
Standard ticket pricing no longer available

### DIFF
--- a/website/2023/toronto/src/pages/index.astro
+++ b/website/2023/toronto/src/pages/index.astro
@@ -216,7 +216,7 @@ const content = {
           <strike>Early Bird - $200 CAD (until Feb 15th or sold out)</strike>
         </p>
         <p class="ticket_size stnd_mr">
-          Standard - $250 CAD (Feb 15th until April 30th) &nbsp;
+          </strike>Standard - $250 CAD (Feb 15th until April 30th) &nbsp;</strike>
         </p>
         <p class="ticket_size">
           Late - $300 CAD (May 1st up until the event start)

--- a/website/2023/toronto/src/pages/index.astro
+++ b/website/2023/toronto/src/pages/index.astro
@@ -216,7 +216,7 @@ const content = {
           <strike>Early Bird - $200 CAD (until Feb 15th or sold out)</strike>
         </p>
         <p class="ticket_size stnd_mr">
-          </strike>Standard - $250 CAD (Feb 15th until April 30th) &nbsp;</strike>
+          <strike>Standard - $250 CAD (Feb 15th until April 30th) &nbsp;</strike>
         </p>
         <p class="ticket_size">
           Late - $300 CAD (May 1st up until the event start)


### PR DESCRIPTION
Standard ticket pricing expired as of April 30th.
<img width="984" alt="image" src="https://user-images.githubusercontent.com/45825464/235519297-1373b9a7-1605-4647-884d-cc703e39cd6e.png">
